### PR TITLE
added Tfidf support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,7 @@ of how to use this library."
                  [org.bytedeco/openblas-platform "0.3.10-1.5.4"]
                  [pppmap/pppmap "0.2.1"]]
 
+
   :profiles
   {:codox
    {:dependencies [[codox-theme-rdash "0.1.2"]]

--- a/src/tech/v3/libs/smile/discrete_nb.clj
+++ b/src/tech/v3/libs/smile/discrete_nb.clj
@@ -46,7 +46,7 @@
   "Predict function for discrete naive bayes"
   (let [sparse-arrays (get feature-ds  (get-in model [:options :sparse-column]))
         target-colum (first (:target-columns model))
-        predictions (map #(.predict (:model-data model) %) sparse-arrays)
+        predictions (map #(.predict thawed-model %) sparse-arrays)
         ]
     (ds/->dataset {target-colum predictions})) )
 

--- a/src/tech/v3/libs/smile/discrete_nb.clj
+++ b/src/tech/v3/libs/smile/discrete_nb.clj
@@ -15,10 +15,10 @@
      freq-map)
     sparse-array))
 
-(defn bow->SparseArray [ds bow-col indices-col vocab-size]
+(defn bow->SparseArray [ds bow-col indices-col create-vocab-fn]
   "Converts a bag-of-word column `bow-col` to sparse indices column `indices-col`,
    as needed by the discrete naive bayes model. `vocab size` is the size of vocabluary used, sorted by token frequency "
-  (nlp/bow->something-sparse ds bow-col indices-col vocab-size freqs->SparseArray))
+  (nlp/bow->something-sparse ds bow-col indices-col create-vocab-fn freqs->SparseArray))
 
 
 (defn train [feature-ds target-ds options]
@@ -44,7 +44,7 @@
                       thawed-model
                       model]
   "Predict function for discrete naive bayes"
-  (let [sparse-arrays (get feature-ds :bow-sparse)
+  (let [sparse-arrays (get feature-ds  (get-in model [:options :sparse-column]))
         target-colum (first (:target-columns model))
         predictions (map #(.predict (:model-data model) %) sparse-arrays)
         ]

--- a/src/tech/v3/libs/smile/maxent.clj
+++ b/src/tech/v3/libs/smile/maxent.clj
@@ -28,11 +28,11 @@
    (into-array Integer/TYPE)))
 
 
-(defn bow->sparse-array [ds bow-col indices-col vocab-size]
+(defn bow->sparse-array [ds bow-col indices-col create-vocab-fn]
   "Converts a bag-of-word column `bow-col` to sparse indices column `indices-col`,
    as needed by the Maxent model.
    `vocab size` is the size of vocabluary used, sorted by token frequency "
-  (nlp/bow->something-sparse ds bow-col indices-col vocab-size bow->sparse-indices))
+  (nlp/bow->something-sparse ds bow-col indices-col create-vocab-fn bow->sparse-indices))
 
 
 (defn maxent-train [feature-ds target-ds options maxent-type]

--- a/src/tech/v3/libs/smile/sparse_svm.clj
+++ b/src/tech/v3/libs/smile/sparse_svm.clj
@@ -19,10 +19,12 @@
    The column of name `(options :sparse-column)` of `feature-ds` needs to contain the text as SparseArrays
    over the vocabulary."
   (let [train-array (into-array SparseArray (get feature-ds (options :sparse-column)))
-        score (get target-ds (first (ds-mod/inference-target-column-names target-ds)))]
+        score (get target-ds (first (ds-mod/inference-target-column-names target-ds)))
+        p (count (-> feature-ds meta :count-vectorize-vocabulary :vocab->index-map))
+        ]
     (SVM/fit train-array
              (dt/->int-array score)
-             ^int (get options :p)
+             p
              ^double (get options :C 1.0)
              ^double (get options :tol 1e-4))))
 
@@ -41,3 +43,4 @@
   train
   predict
   {})
+

--- a/test/tech/v3/libs/smile/discrete_nb_test.clj
+++ b/test/tech/v3/libs/smile/discrete_nb_test.clj
@@ -15,7 +15,7 @@
    (ds/select-columns [:Text :Score])
    (ds/update-column :Score #(map dec %))
    (nlp/count-vectorize :Text :bow nlp/default-text->bow)
-   (nb/bow->SparseArray :bow :bow-sparse 100)
+   (nb/bow->SparseArray :bow :bow-sparse #(nlp/->vocabulary-top-n % 100) )
    (ds-mod/set-inference-target :Score)))
 
 
@@ -53,3 +53,28 @@
               prediction (ml/predict (ds/head reviews 10) trained-model)]
           prediction))
        [4 4 3 2 3 4 4 4 4 4])))
+
+
+
+
+(comment
+
+  (def reviews (get-reviews))
+
+
+  (def reviews
+    (-> reviews
+        (nlp/bow->tfidf :bow :tfidf)
+
+        ))
+
+  (def reviews
+    (nb/bow->SparseArray reviews :tfidf :sparse  (fn [bows] (nlp/->vocabulary-top-n bows 100))))
+
+  (def trained-model
+    (ml/train reviews {:model-type :discrete-naive-bayes
+                       :discrete-naive-bayes-model :multinomial
+                       :sparse-column :sparse
+                       :k 5}))
+  (ml/predict reviews trained-model)
+  )

--- a/test/tech/v3/libs/smile/discrete_nb_test.clj
+++ b/test/tech/v3/libs/smile/discrete_nb_test.clj
@@ -53,28 +53,3 @@
               prediction (ml/predict (ds/head reviews 10) trained-model)]
           prediction))
        [4 4 3 2 3 4 4 4 4 4])))
-
-
-
-
-(comment
-
-  (def reviews (get-reviews))
-
-
-  (def reviews
-    (-> reviews
-        (nlp/bow->tfidf :bow :tfidf)
-
-        ))
-
-  (def reviews
-    (nb/bow->SparseArray reviews :tfidf :sparse  (fn [bows] (nlp/->vocabulary-top-n bows 100))))
-
-  (def trained-model
-    (ml/train reviews {:model-type :discrete-naive-bayes
-                       :discrete-naive-bayes-model :multinomial
-                       :sparse-column :sparse
-                       :k 5}))
-  (ml/predict reviews trained-model)
-  )

--- a/test/tech/v3/libs/smile/maxent_test.clj
+++ b/test/tech/v3/libs/smile/maxent_test.clj
@@ -12,7 +12,7 @@
    (ds/->dataset "test/data/reviews.csv.gz" {:key-fn keyword })
    (ds/select-columns [:Text :Score])
    (nlp/count-vectorize :Text :bow nlp/default-text->bow)
-   (maxent/bow->sparse-array :bow :bow-sparse 1000)
+   (maxent/bow->sparse-array :bow :bow-sparse  #(nlp/->vocabulary-top-n % 1000))
    (ds-mod/set-inference-target :Score)))
 
 (deftest test-maxent-multinomial []

--- a/test/tech/v3/libs/smile/nlp_test.clj
+++ b/test/tech/v3/libs/smile/nlp_test.clj
@@ -1,0 +1,28 @@
+(ns tech.v3.libs.smile.nlp-test
+  (:require [tech.v3.libs.smile.nlp :as nlp]
+            [tech.v3.dataset :as ds]
+            [clojure.test :refer [deftest is] :as t]))
+
+(deftest calculate-tfidf
+
+  (let [bows [{:this 1 :is 1 :a 2 :sample 1}
+              {:this 1 :is 1 :another 2 :example 3 }]
+        tf-map (nlp/tf-map bows)
+        bow-1 (first bows)
+        bow-2 (second bows)]
+    (is (= 0.0  (nlp/tfidf tf-map :example bow-1  bows)))
+    (is (= 0.12901285528456338  (nlp/tfidf tf-map :example bow-2  bows)))))
+
+
+(deftest bow->tfidf
+  (let [ds (->
+            (ds/->dataset {:text ["This is a a sample"  "this is another another example example example" ]})
+            (nlp/count-vectorize :text :bow nlp/default-text->bow)
+            (nlp/bow->tfidf :bow :tfidf)
+            )
+        tfidf-1 (first (:tfidf ds))
+        tfidf-2 (second (:tfidf ds))
+        ]
+    (is (= 0.12901285528456338 (get tfidf-2 "exampl")))
+    (is (= 0.12041199826559248 (get tfidf-1 "a")))
+    (is (= 0.0 (get tfidf-1 "thi")))))

--- a/test/tech/v3/libs/smile/sparse_logreg_test.clj
+++ b/test/tech/v3/libs/smile/sparse_logreg_test.clj
@@ -13,14 +13,16 @@
    (ds/select-columns [:Text :Score])
    (ds/update-column :Score #(map dec %))
    (nlp/count-vectorize :Text :bow nlp/default-text->bow)
-   (nb/bow->SparseArray :bow :bow-sparse #(nlp/->vocabulary-top-n % 100))
+   (nb/bow->SparseArray :bow :sparse #(nlp/->vocabulary-top-n % 100))
    (ds-mod/set-inference-target :Score)))
+
+
 
 (deftest does-not-crash
   (let [reviews (get-reviews)
         trained-model
         (ml/train reviews {:model-type :smile.classification/sparse-logistic-regression
-                          :sparse-column :bow-sparse})]
+                           :sparse-column :sparse})]
 
     (is (= [4 4 4 2]
            (take 4

--- a/test/tech/v3/libs/smile/sparse_logreg_test.clj
+++ b/test/tech/v3/libs/smile/sparse_logreg_test.clj
@@ -13,7 +13,7 @@
    (ds/select-columns [:Text :Score])
    (ds/update-column :Score #(map dec %))
    (nlp/count-vectorize :Text :bow nlp/default-text->bow)
-   (nb/bow->SparseArray :bow :bow-sparse 100)
+   (nb/bow->SparseArray :bow :bow-sparse #(nlp/->vocabulary-top-n % 100))
    (ds-mod/set-inference-target :Score)))
 
 (deftest does-not-crash

--- a/test/tech/v3/libs/smile/sparse_svm_test.clj
+++ b/test/tech/v3/libs/smile/sparse_svm_test.clj
@@ -16,14 +16,19 @@
                                             +1 -1))
                                 %))
      (nlp/count-vectorize :Text :bow nlp/default-text->bow)
-     (nb/bow->SparseArray :bow :bow-sparse 100)
+     (nb/bow->SparseArray :bow :bow-sparse #(nlp/->vocabulary-top-n % 100))
      (ds-mod/set-inference-target :Score)))
 
 (deftest does-not-crash
   (let [reviews (get-reviews)
+        _ (def reviews reviews)
         trained-model
         (ml/train reviews {:model-type :smile.classification/sparse-svm
                            :sparse-column :bow-sparse
-                           :p 100})]
+                           })]
+    (def trained-model trained-model)
     (is (= {-1 :6 1 :994})
         (frequencies (:Score (ml/predict reviews trained-model))))))
+
+(count
+ (-> reviews meta :count-vectorize-vocabulary :vocab->index-map))

--- a/test/tech/v3/libs/xgboost_test.clj
+++ b/test/tech/v3/libs/xgboost_test.clj
@@ -7,6 +7,7 @@
             [tech.v3.datatype.functional :as dfn]
             [tech.v3.libs.smile.discrete-nb :as nb]
             [tech.v3.libs.smile.nlp :as nlp]
+            [tech.v3.libs.xgboost]
             [tech.v3.ml :as ml]
             [tech.v3.ml.loss :as loss]
             [tech.v3.ml.verify :as verify]

--- a/test/tech/v3/libs/xgboost_test.clj
+++ b/test/tech/v3/libs/xgboost_test.clj
@@ -10,8 +10,7 @@
             [tech.v3.ml :as ml]
             [tech.v3.ml.loss :as loss]
             [tech.v3.ml.verify :as verify]
-            [tech.v3.libs.xgboost]
-            ))
+            [tech.v3.libs.xgboost]))
 
 (deftest basic
   (verify/basic-regression {:model-type :xgboost/regression}))

--- a/test/tech/v3/libs/xgboost_test.clj
+++ b/test/tech/v3/libs/xgboost_test.clj
@@ -7,10 +7,10 @@
             [tech.v3.datatype.functional :as dfn]
             [tech.v3.libs.smile.discrete-nb :as nb]
             [tech.v3.libs.smile.nlp :as nlp]
-            [tech.v3.libs.xgboost]
             [tech.v3.ml :as ml]
             [tech.v3.ml.loss :as loss]
             [tech.v3.ml.verify :as verify]
+            [tech.v3.libs.xgboost]
             ))
 
 (deftest basic

--- a/test/tech/v3/libs/xgboost_test.clj
+++ b/test/tech/v3/libs/xgboost_test.clj
@@ -62,7 +62,7 @@
            (ds/->dataset "test/data/reviews.csv.gz" {:key-fn keyword })
            (ds/select-columns [:Text :Score])
            (nlp/count-vectorize :Text :bow nlp/default-text->bow)
-           (nb/bow->SparseArray :bow :bow-sparse 100)
+           (nb/bow->SparseArray :bow :bow-sparse  #(nlp/->vocabulary-top-n % 100))
            (ds/drop-columns [:Text :bow])
            (ds/update-column :Score
                              (fn [col]

--- a/test/tech/v3/ml_test.clj
+++ b/test/tech/v3/ml_test.clj
@@ -11,7 +11,7 @@
     {:dataset
      (-> ds
          (nlp/count-vectorize :Text :bow nlp/default-text->bow options)
-         (nb/bow->SparseArray :bow :bow-sparse (:vocab-size options))
+         (nb/bow->SparseArray :bow :bow-sparse #(nlp/->vocabulary-top-n %  (:vocab-size options)))
          )
      :options (merge  options {:a 1})})
 


### PR DESCRIPTION
This PR add the possibility to convert the bow text representation into a  tfidf representation.

With this we can use tech.ml to implement **the**  default approach to text classification, namely the combination of:
- bag-of-word representation
- tfidf score as features
- sparse logistic regression as model

sometimes called the "Logistic regression-Tf-Idf baseline".

This allows to implement somethonk like this 

https://www.kaggle.com/kashnitsky/logistic-regression-tf-idf-baseline

in Clojure.
