### PR TITLE
made the number of sparse dataset cols configurable.

### DIFF
--- a/src/tech/v3/libs/smile/sparse_logreg.clj
+++ b/src/tech/v3/libs/smile/sparse_logreg.clj
@@ -21,7 +21,7 @@
    over the vocabulary."
   (let [train-array (into-array SparseArray
                                 (get feature-ds (:sparse-column options)))
-        train-dataset (SparseDataset/of (seq train-array))
+        train-dataset (SparseDataset/of (seq train-array) (options :n-sparse-columns))
         score (get target-ds (first (ds-mod/inference-target-column-names target-ds)))]
     (SparseLogisticRegression/fit train-dataset
                                   (dt/->int-array score)

--- a/test/tech/v3/libs/smile/sparse_logreg_test.clj
+++ b/test/tech/v3/libs/smile/sparse_logreg_test.clj
@@ -22,6 +22,7 @@
   (let [reviews (get-reviews)
         trained-model
         (ml/train reviews {:model-type :smile.classification/sparse-logistic-regression
+                           :n-sparse-columns 100
                            :sparse-column :sparse})]
 
     (is (= [4 4 4 2]


### PR DESCRIPTION
The test-set could have higher col numbers then the train data and a sparse dataset has not a fixed number of cols.
By default the ncol is set to the "largest" sparse data point  found in training data.

This makes prediction crash, if test data has "more right" data points the training data.